### PR TITLE
Issue#1: CMakeLists.txt has been updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 # Add the executable
 add_executable(SAGE 
 	src/SAGE.cpp
+	src/SAGE_Engine.cpp
 	src/Parser.cpp
 	src/Logger.cpp
 	src/DataFrame.cpp


### PR DESCRIPTION
Solution for Issue#1 is simple. We had to add SAGE_Engine.cpp to the CMakeLists.txt file. Once added, the Linker had access to implementation for methods listed in SAGE_Engine.h. Based on this, I tested the theory on my local repo and found that to work.